### PR TITLE
DB_NAME as variable to not use postgres schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ RUN pip install -r /app/requirements.txt
 #ENV DB_HOST 127.0.0.1
 #ENV DB_USER postgres
 #ENV DB_PASS password
+#ENV DB_NAME memegen

--- a/gmemegen_deployment.yaml
+++ b/gmemegen_deployment.yaml
@@ -42,6 +42,11 @@ spec:
                 secretKeyRef:
                   name: cloudsql-db-credentials
                   key: password
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-db-credentials
+                  key: dbname
         # Change <INSTANCE_CONNECTION_NAME> here to include your GCP
         # project, the region of your Cloud SQL instance and the name
         # of your Cloud SQL instance. The format is $PROJECT:$REGION:$INSTANCE


### PR DESCRIPTION
Before it was using the `postgres` schema, I updated the code and the codelab to pass `DB_NAME` as an option.